### PR TITLE
Added the capability to also dissolve (edit opacity for) the watermark.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ gulp.src("./src/*.ext")
 	.pipe(watermark({
 		image: "test/fixtures/github.png",
         resize: '100x100',
-        gravity: 'Center'
+        gravity: 'Center',
+        dissolve: 30
 	}))
 	.pipe(gulp.dest("./dist"));
 ```
@@ -52,6 +53,14 @@ Default: `SouthEast`
 Possible values: `NorthWest`, `North`, `NorthEast`, `West`, `Center`, `East`, `SouthWest`, `South`, `SouthEast`
 
 The direction the primitive gravitates to when annotating the watermark image. Defaults to SouthEast.
+
+#### options.dissolve
+Type: `Number`<br>
+Default: `100`
+
+Possible values: `0-100`
+
+Indicates the level of dissolve from 0 to 100. 0 is completely transparent, and 100 is completely opaque.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -50,14 +50,19 @@ module.exports = function (param) {
 			 *
 			 * -resize
 			 *   Ex. 50%
+			 *
+			 * -dissolve
+			 *   Ex. 50
 			 */
 			var gravity = param.gravity || 'SouthEast';
 			var resize = param.resize || '100%';
+			var dissolve = param.dissolve || '100';
 			var background = param.background || 'none';
 			gm(file.contents, file.path)
 				.command('composite')
 				.in('-gravity', gravity)
 				.in('-resize', resize)
+				.in('-dissolve', dissolve)
 				.in('-background', background)
 				.in(param.image)
 				.toBuffer(function(err, buffer) {


### PR DESCRIPTION
Addresses the issue brought up with https://github.com/HAKASHUN/gulp-watermark/issues/2 about adding transparency.